### PR TITLE
added package-lock.json to vscode excluded files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "**/build": true,
         "**/lib": true,
         "package.json": true,
+        "package-lock.json": true,
         "tsconfig.json": true,
         "tslint.json": true
     },


### PR DESCRIPTION
Starting in version 5 npm automatically creates a package-lock.json file and this should be hidden from students.